### PR TITLE
Possible fix for the encoding bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
 
 python:
-    - 3.3
-    - 3.4
     - 3.5
-    - nightly
+    - "3.5-dev"
+    - 3.6
+    - "3.6-dev"
+    - "3.7-dev"
+    - "nightly"
 
 sudo: required
 # do we need sudo? should double check

--- a/bin/filecheck.py
+++ b/bin/filecheck.py
@@ -576,13 +576,13 @@ class GroomerLogger(object):
         return path_depth
 
     def _write_line_to_log(self, line, indentation_depth):
-        padding = b'   '
-        padding += b'|  ' * indentation_depth
+        padding = '   '
+        padding += '|  ' * indentation_depth
         line_bytes = os.fsencode(line)
-        with open(self.log_path, mode='ab') as lf:
+        with open(self.log_path, mode='a') as lf:
             lf.write(padding)
-            lf.write(line_bytes)
-            lf.write(b'\n')
+            lf.write(line_bytes.decode('utf-8', 'backslashreplace'))
+            lf.write('\n')
 
 
 class KittenGroomerFileCheck(KittenGroomerBase):


### PR DESCRIPTION
I had a very similar issue today, and starting to mess with `backslashreplace` (only available in python >= 3.5). 

In case we want to still support python 3.4, the hotfix look like that:

``` python
# === PYTHON 3.0 - 3.4 SUPPORT ======================================================

# From https://gist.github.com/ynkdir/867347/c5e188a4886bc2dd71876c7e069a7b00b6c16c61
import sys
if sys.version_info >= (3, 0) and sys.version_info < (3, 5):
    import codecs

    _backslashreplace_errors = codecs.lookup_error("backslashreplace")

    def backslashreplace_errors(exc):
        if isinstance(exc, UnicodeDecodeError):
            u = "".join("\\x{0:02x}".format(c) for c in exc.object[exc.start:exc.end])
            return (u, exc.end)
        return _backslashreplace_errors(exc)

    codecs.register_error("backslashreplace", backslashreplace_errors)

```